### PR TITLE
feat(backend): Add JaCoCo test coverage enforcement

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<spring-modulith.version>1.4.1</spring-modulith.version>
+		<spring.output.ansi.enabled>always</spring.output.ansi.enabled>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -178,6 +179,11 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.5.3</version>
+			</plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.12</version>
@@ -222,6 +228,9 @@
 									</limits>
 								</rule>
 							</rules>
+							<excludes>
+								<exclude>**/BackendApplication.class</exclude>
+							</excludes>
 						</configuration>
 					</execution>
 				</executions>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -177,6 +177,55 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+
+					<execution>
+						<id>check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>INSTRUCTION</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.80</minimum>
+										</limit>
+										<limit>
+											<counter>BRANCH</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.75</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend/src/main/java/net/anshin/pet/backend/service/CalculatorService.java
+++ b/backend/src/main/java/net/anshin/pet/backend/service/CalculatorService.java
@@ -1,0 +1,14 @@
+package net.anshin.pet.backend.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CalculatorService {
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+    public int subtract(int a, int b) {
+        return a - b;
+    }
+}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!--
+        - %clr(...){...}: Applies color.
+        - %d{HH:mm:ss.SSS}: A short timestamp (Hour:Minute:Second.Millisecond).
+        - ${LOG_LEVEL_PATTERN:-%5p}: The log level (INFO, DEBUG, etc.), padded to 5 characters.
+        - %-40.40logger{39}: The name of the logger, truncated to 40 characters.
+        - %m%n: The actual log message, followed by a new line.
+    -->
+    <property name="SIMPLE_CONSOLE_LOG_PATTERN"
+              value="%d{HH:mm:ss.SSS} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${SIMPLE_CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+
+    <logger name="net.anshin.pet.backend" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+    <logger name="org.flywaydb" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/backend/src/test/java/net/anshin/pet/backend/service/CalculatorServiceTest.java
+++ b/backend/src/test/java/net/anshin/pet/backend/service/CalculatorServiceTest.java
@@ -11,4 +11,9 @@ class CalculatorServiceTest {
     void add() {
         assertEquals(5, calculatorService.add(2, 3));
     }
+
+    @Test
+    void subtract() {
+        assertEquals(1, calculatorService.subtract(3, 2));
+    }
 }

--- a/backend/src/test/java/net/anshin/pet/backend/service/CalculatorServiceTest.java
+++ b/backend/src/test/java/net/anshin/pet/backend/service/CalculatorServiceTest.java
@@ -1,0 +1,14 @@
+package net.anshin.pet.backend.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+class CalculatorServiceTest {
+
+    private final CalculatorService calculatorService = new CalculatorService();
+
+    @Test
+    void add() {
+        assertEquals(5, calculatorService.add(2, 3));
+    }
+}


### PR DESCRIPTION
This PR introduces a critical quality gate to the backend build process, ensuring all future code meets a minimum test coverage standard.

### Key Changes Implemented:

-   **JaCoCo Coverage Check:**
    -   The `jacoco-maven-plugin` is now configured to enforce a minimum test coverage threshold (e.g., 80% for instructions).
    -   The `pre-push` hook now automatically fails if the code being pushed does not meet this standard, preventing untested code from reaching the repository.
    -   The main `BackendApplication.class` has been excluded from the calculation as it contains no business logic.

-   **Improved Logging:**
    -   A `logback-spring.xml` has been added to provide cleaner, more readable, and color-coded console output.
    -   The `maven-surefire-plugin` is configured to ensure these log colors are preserved during the test phase.

### Verification Method:

A temporary `CalculatorService` and its corresponding tests were used to verify the new quality gate. It was confirmed that:
1.  The `git push` command **fails** when test coverage is below the threshold.
2.  The `git push` command **succeeds** when test coverage is above the threshold.